### PR TITLE
chatgpt: recover empty SSE outputs

### DIFF
--- a/swival/__init__.py
+++ b/swival/__init__.py
@@ -5,6 +5,15 @@ from .report import ConfigError as ConfigError
 from .report import ContextOverflowError as ContextOverflowError
 from .report import LifecycleError as LifecycleError
 
+from . import agent as _agent
+from ._chatgpt_compat import (
+    patch_chatgpt_responses_empty_output as _patch_chatgpt_responses_empty_output,
+)
+
+_agent._patch_chatgpt_responses_empty_output = _patch_chatgpt_responses_empty_output
+
+del _agent, _patch_chatgpt_responses_empty_output
+
 
 def run(question: str, *, base_dir: str = ".", **kwargs) -> str:
     """One-call convenience. Returns the answer string or raises AgentError."""

--- a/swival/_chatgpt_compat.py
+++ b/swival/_chatgpt_compat.py
@@ -1,0 +1,179 @@
+"""Compatibility patches for LiteLLM's ChatGPT subscription adapter."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from typing import Any
+
+
+StripSseData = Callable[[str], str | None]
+
+
+def _sse_json_events(body_text: str, strip_sse_data: StripSseData) -> Iterator[dict]:
+    for line in body_text.splitlines():
+        stripped = strip_sse_data(line)
+        if not stripped:
+            continue
+        stripped = stripped.strip()
+        if not stripped:
+            continue
+        if stripped == "[DONE]":
+            break
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            yield parsed
+
+
+def _event_index(event: dict, fallback: int) -> int:
+    raw = event.get("output_index", fallback)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _content_index(event: dict) -> int:
+    raw = event.get("content_index", 0)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def output_items_from_sse(body_text: str, strip_sse_data: StripSseData) -> list[dict]:
+    """Recover Responses API output items from ChatGPT SSE events."""
+    added_items: dict[int, dict] = {}
+    done_items: dict[int, dict] = {}
+    text_chunks: dict[tuple[int, int], list[str]] = {}
+    text_done: dict[tuple[int, int], str] = {}
+    text_annotations: dict[tuple[int, int], list[Any]] = {}
+    arg_chunks: dict[int, list[str]] = {}
+    arg_done: dict[int, str] = {}
+
+    for event in _sse_json_events(body_text, strip_sse_data):
+        event_type = event.get("type")
+        if event_type == "response.output_item.added":
+            item = event.get("item")
+            if isinstance(item, dict):
+                added_items[_event_index(event, len(added_items))] = dict(item)
+        elif event_type == "response.output_item.done":
+            item = event.get("item")
+            if isinstance(item, dict):
+                done_items[_event_index(event, len(done_items))] = dict(item)
+        elif event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                key = (_event_index(event, 0), _content_index(event))
+                text_chunks.setdefault(key, []).append(delta)
+        elif event_type == "response.output_text.done":
+            text = event.get("text")
+            if isinstance(text, str):
+                key = (_event_index(event, 0), _content_index(event))
+                text_done[key] = text
+        elif event_type == "response.content_part.done":
+            part = event.get("part")
+            if isinstance(part, dict) and part.get("type") == "output_text":
+                text = part.get("text")
+                key = (_event_index(event, 0), _content_index(event))
+                if isinstance(text, str):
+                    text_done[key] = text
+                annotations = part.get("annotations")
+                if isinstance(annotations, list):
+                    text_annotations[key] = annotations
+        elif event_type == "response.function_call_arguments.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                idx = _event_index(event, 0)
+                arg_chunks.setdefault(idx, []).append(delta)
+        elif event_type == "response.function_call_arguments.done":
+            arguments = event.get("arguments")
+            if isinstance(arguments, str):
+                arg_done[_event_index(event, 0)] = arguments
+
+    def text_content(output_index: int) -> list[dict]:
+        keys = sorted(
+            key for key in set(text_chunks) | set(text_done) if key[0] == output_index
+        )
+        return [
+            {
+                "type": "output_text",
+                "text": text_done.get(key, "".join(text_chunks.get(key, []))),
+                "annotations": text_annotations.get(key, []),
+            }
+            for key in keys
+        ]
+
+    def fill_item(output_index: int, item: dict) -> dict:
+        item = dict(item)
+        if item.get("type") == "message":
+            content = item.get("content")
+            has_text = (
+                isinstance(content, list)
+                and any(
+                    isinstance(part, dict)
+                    and part.get("type") == "output_text"
+                    and part.get("text")
+                    for part in content
+                )
+            )
+            recovered_content = text_content(output_index)
+            if recovered_content and not has_text:
+                item["content"] = recovered_content
+            item.setdefault("role", "assistant")
+        elif item.get("type") == "function_call":
+            arguments = arg_done.get(output_index)
+            if arguments is None and output_index in arg_chunks:
+                arguments = "".join(arg_chunks[output_index])
+            if arguments is not None and not item.get("arguments"):
+                item["arguments"] = arguments
+        return item
+
+    source_items = {**added_items, **done_items}
+    for output_index in {key[0] for key in set(text_chunks) | set(text_done)}:
+        if output_index not in source_items:
+            source_items[output_index] = {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": text_content(output_index),
+            }
+
+    return [
+        fill_item(output_index, source_items[output_index])
+        for output_index in sorted(source_items)
+    ]
+
+
+def patch_chatgpt_responses_empty_output() -> None:
+    """Patch LiteLLM to recover ChatGPT SSE output when completion output is empty."""
+    try:
+        from litellm.llms.chatgpt.responses.transformation import (
+            ChatGPTResponsesAPIConfig,
+        )
+        from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    except ImportError:
+        return
+
+    if getattr(ChatGPTResponsesAPIConfig, "_swival_patched", False):
+        return
+    ChatGPTResponsesAPIConfig._swival_patched = True
+
+    original = ChatGPTResponsesAPIConfig.transform_response_api_response
+    strip_sse_data = CustomStreamWrapper._strip_sse_data_from_chunk
+
+    def patched_transform(self, model, raw_response, logging_obj):
+        result = original(self, model, raw_response, logging_obj)
+        if getattr(result, "output", None):
+            return result
+
+        body_text = getattr(raw_response, "text", None) or ""
+        output_items = output_items_from_sse(body_text, strip_sse_data)
+        if output_items:
+            result.output = output_items
+        return result
+
+    ChatGPTResponsesAPIConfig.transform_response_api_response = patched_transform

--- a/tests/test_chatgpt_compat.py
+++ b/tests/test_chatgpt_compat.py
@@ -1,0 +1,95 @@
+from swival._chatgpt_compat import output_items_from_sse
+
+
+def _strip_sse_test_line(line):
+    return line[5:] if line.startswith("data:") else ""
+
+
+def test_recovers_output_item_done():
+    body = (
+        'event: response.output_item.done\n'
+        'data: {"type":"response.output_item.done","output_index":0,'
+        '"item":{"type":"message","role":"assistant","content":'
+        '[{"type":"output_text","text":"ok"}]}}\n'
+    )
+
+    assert output_items_from_sse(body, _strip_sse_test_line) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "ok"}],
+        }
+    ]
+
+
+def test_recovers_text_when_completed_output_is_empty():
+    body = (
+        'event: response.output_text.delta\n'
+        'data: {"type":"response.output_text.delta","output_index":0,'
+        '"content_index":0,"delta":"Hello "}\n'
+        'event: response.output_text.done\n'
+        'data: {"type":"response.output_text.done","output_index":0,'
+        '"content_index":0,"text":"Hello world"}\n'
+        'event: response.completed\n'
+        'data: {"type":"response.completed","response":{"output":[]}}\n'
+    )
+
+    assert output_items_from_sse(body, _strip_sse_test_line) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Hello world",
+                    "annotations": [],
+                }
+            ],
+        }
+    ]
+
+
+def test_fills_empty_message_content_from_text_stream():
+    body = (
+        'event: response.output_item.done\n'
+        'data: {"type":"response.output_item.done","output_index":0,'
+        '"item":{"type":"message","role":"assistant","content":[]}}\n'
+        'event: response.output_text.delta\n'
+        'data: {"type":"response.output_text.delta","output_index":0,'
+        '"content_index":0,"delta":"Recovered"}\n'
+    )
+
+    assert output_items_from_sse(body, _strip_sse_test_line) == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Recovered", "annotations": []}
+            ],
+        }
+    ]
+
+
+def test_recovers_function_call_arguments_from_stream():
+    body = (
+        'event: response.output_item.added\n'
+        'data: {"type":"response.output_item.added","output_index":0,'
+        '"item":{"type":"function_call","call_id":"call_1","name":"read_file",'
+        '"arguments":""}}\n'
+        'event: response.function_call_arguments.delta\n'
+        'data: {"type":"response.function_call_arguments.delta",'
+        '"output_index":0,"delta":"{\\"path\\":"}\n'
+        'event: response.function_call_arguments.delta\n'
+        'data: {"type":"response.function_call_arguments.delta",'
+        '"output_index":0,"delta":"\\"README.md\\"}"}\n'
+    )
+
+    assert output_items_from_sse(body, _strip_sse_test_line) == [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "read_file",
+            "arguments": '{"path":"README.md"}',
+        }
+    ]


### PR DESCRIPTION
## What changed

- Adds a ChatGPT/LiteLLM compatibility patch that recovers Responses API output items from raw SSE events when `response.completed` returns `output: []`.
- Preserves existing `response.output_item.done` recovery while also rebuilding assistant text from `response.output_text.delta`, `response.output_text.done`, and `response.content_part.done` events.
- Recovers streamed function-call arguments from `response.function_call_arguments.delta` / `response.function_call_arguments.done` so tool calls still round-trip through LiteLLM's chat-completion bridge.
- Adds focused unit coverage for output-item, empty-text-output, empty-message-content, and function-call-argument recovery.

## Why

`swival "Hello world" --provider chatgpt --model gpt-5.4` can fail through LiteLLM with:

```text
ChatgptException - Unknown items in responses API response: []
API response: []
```

The ChatGPT backend may stream usable SSE events even though the final completed response has an empty `output` array. LiteLLM then cannot convert the response to chat-completion choices. This patch gives Swival a narrow compatibility shim until LiteLLM handles that stream shape natively.

## Validation

I attempted to run the requested live smoke tests locally:

```powershell
swival "Hello world" --provider chatgpt --model gpt-5.4 --max-turns 1 --no-history
swival "Hello world" --provider chatgpt --model gpt-5.5 --max-turns 1 --no-history
```

However, the VS Code Copilot CLI runtime could not launch any local command, including Windows Terminal or `winget`, because the tool bootstrap fails before commands start:

```text
'pwsh.exe' is not recognized as an internal or external command
```

I could not run `uv run pytest tests\test_chatgpt_compat.py tests\test_provider.py -q`, `uv run ruff check ...`, or the live `gpt-5.4`/`gpt-5.5` provider calls from this environment for the same reason. Reviewers should run those commands in an environment with PowerShell Core or another working shell and valid ChatGPT OAuth credentials.