### PR TITLE
Fix metaskills install command in docs and runtime hint

### DIFF
--- a/docs.md/metaskills.md
+++ b/docs.md/metaskills.md
@@ -11,10 +11,11 @@ of a task that should be repeatable, bounded, and easy to inspect.
 ## 0. Installation
 
 Metaskill execution needs the Starlark runtime, which ships as an optional
-extra so the base install stays lean:
+extra so the base install stays lean. Install it with the same tool you used
+to install Swival:
 
 ```sh
-pip install 'swival[metaskills]'
+uv tool install 'swival[metaskills]'
 ```
 
 Without it Swival still discovers metaskill-bearing skills, but treats them as

--- a/docs.md/skills.md
+++ b/docs.md/skills.md
@@ -117,6 +117,6 @@ Project-local skills are already inside normal sandbox roots, so they use standa
 
 A skill directory can also contain a program file (`SKILL.star`) that turns it into an Agent MetaSKILL — a dynamic workflow that runs bounded loops with nested model calls, command execution, and structured tracing. When a `SKILL.star` file is present (or the `metaskill` frontmatter field points to one), Swival exposes the `run_metaskill` tool alongside `use_skill`.
 
-MetaSKILLs use Starlark as their runtime language and expose three host functions: `ask()`, `command()`, and `trace()`. Execution requires the optional Starlark runtime (installed with `pip install 'swival[metaskills]'`); without it, these skills behave as ordinary static skills. Local metaskills execute by default; external metaskills require `--metaskills all` or `metaskills = "all"` in config.
+MetaSKILLs use Starlark as their runtime language and expose three host functions: `ask()`, `command()`, and `trace()`. Execution requires the optional Starlark runtime (installed with `uv tool install 'swival[metaskills]'`); without it, these skills behave as ordinary static skills. Local metaskills execute by default; external metaskills require `--metaskills all` or `metaskills = "all"` in config.
 
 See the [Agent MetaSKILLs specification](metaskills.md) for the full format, host API, budgets, and authoring guide.

--- a/swival/metaskills.py
+++ b/swival/metaskills.py
@@ -403,7 +403,7 @@ def run_metaskill(
     if not _check_starlark_available():
         return (
             "error: starlark runtime not installed. "
-            "Install with: pip install 'swival[metaskills]'"
+            "Install with: uv tool install 'swival[metaskills]'"
         )
 
     try:


### PR DESCRIPTION
The `metaskills` extra was documented as `pip install 'swival[metaskills]'`, but Swival is installed via `uv tool install swival` (or Homebrew), so pip targets the wrong environment and the extra never reaches the tool's venv. README already used the uv form; this makes the rest consistent.

- `docs.md/metaskills.md` (§0) and `docs.md/skills.md`: install with `uv tool install 'swival[metaskills]'`
- `swival/metaskills.py`: the "runtime not installed" error now suggests the uv command

Verified: `uv tool install 'swival[metaskills]'` installs starlark-go into the tool venv and `_check_starlark_available()` returns True; `tests/test_metaskills.py` 40 passed, `ruff` clean.